### PR TITLE
Add OpenAI API Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,12 +2,24 @@
 # 必須設定（これらがないと起動しません）
 # ===========================================
 
+# 使用するAIプロバイダー（gemini または openai）
+AI_PROVIDER=gemini
+
+# ===== Gemini API設定 =====
 # Google AI Studio APIキー
 # 取得先: https://aistudio.google.com/app/apikey
-GEMINI_API_KEY=your_api_key_here
+GEMINI_API_KEY=your_gemini_api_key_here
 
 # 使用するGeminiモデル
-MODEL_NAME=gemini-2.0-flash
+GEMINI_MODEL_NAME=gemini-2.0-flash
+
+# ===== OpenAI API設定 =====
+# OpenAI APIキー
+# 取得先: https://platform.openai.com/api-keys
+OPENAI_API_KEY=your_openai_api_key_here
+
+# 使用するOpenAIモデル
+OPENAI_MODEL_NAME=gpt-4.1-mini
 
 # ===========================================
 # 任意設定（デフォルト値あり）

--- a/README.ja.md
+++ b/README.ja.md
@@ -27,7 +27,10 @@
 ### 必要要件
 
 - Python 3.8以上
-- Google AI Studio APIキー（[取得はこちら](https://aistudio.google.com/app/apikey)）
+- pip (Pythonパッケージマネージャー、通常はPythonに含まれています)
+- APIキー（使用するプロバイダーに応じて）
+  - Google AI Studio APIキー（[取得はこちら](https://aistudio.google.com/app/apikey)）
+  - または OpenAI APIキー（[取得はこちら](https://platform.openai.com/api-keys)）
 
 ### インストール手順
 
@@ -77,12 +80,20 @@ cp .env.example .env
 
 #### 2. APIキーの設定
 
-テキストエディタで`.env`ファイルを開き、必須項目を設定：
+テキストエディタで`.env`ファイルを開き、使用するAIプロバイダーに応じて設定：
 
+**Gemini APIを使用する場合（デフォルト）：**
 ```bash
-# 必須項目のみ変更が必要（他の項目はデフォルト値で動作）
+AI_PROVIDER=gemini
 GEMINI_API_KEY=ここに取得したAPIキーを貼り付け
-MODEL_NAME=gemini-2.0-flash  # または gemini-2.5-pro など
+GEMINI_MODEL_NAME=gemini-2.0-flash  # または gemini-2.5-pro など
+```
+
+**OpenAI APIを使用する場合：**
+```bash
+AI_PROVIDER=openai
+OPENAI_API_KEY=ここに取得したAPIキーを貼り付け
+OPENAI_MODEL_NAME=gpt-4.1-mini  # または gpt-4.1 など
 ```
 
 **重要**: `.env`ファイルには機密情報が含まれるため、絶対にGitにコミットしないでください。
@@ -96,6 +107,11 @@ python app.py
 
 起動に成功すると以下のようなメッセージが表示されます：
 ```
+=== Avatar UI Core ===
+AI Provider: gemini  # または openai
+Model: gemini-2.0-flash  # または gpt-4.1-mini など
+Server running at: http://localhost:5000
+====================
  * Running on http://127.0.0.1:5000
 ```
 
@@ -169,8 +185,13 @@ BEEP_DURATION_MS=30     # 音の長さ（ミリ秒）
 
 | 変数名 | 説明 | デフォルト値 | 必須 |
 |--------|------|-------------|------|
-| `GEMINI_API_KEY` | Google Gemini APIキー | - | ✅ |
-| `MODEL_NAME` | 使用するGeminiモデル | gemini-2.0-flash | ✅ |
+| `AI_PROVIDER` | 使用するAIプロバイダー（gemini/openai） | gemini | ✅ |
+| **Gemini API設定** | | | |
+| `GEMINI_API_KEY` | Google Gemini APIキー | - | ※1 |
+| `GEMINI_MODEL_NAME` | 使用するGeminiモデル | gemini-2.0-flash | |
+| **OpenAI API設定** | | | |
+| `OPENAI_API_KEY` | OpenAI APIキー | - | ※2 |
+| `OPENAI_MODEL_NAME` | 使用するOpenAIモデル | gpt-4.1-mini | |
 | **サーバー設定** | | | |
 | `SERVER_PORT` | サーバーポート番号 | 5000 | |
 | `DEBUG_MODE` | デバッグモード有効化 | True | |
@@ -190,11 +211,15 @@ BEEP_DURATION_MS=30     # 音の長さ（ミリ秒）
 | `BEEP_VOLUME` | ビープ音の音量（0.0-1.0） | 0.05 | |
 | `BEEP_VOLUME_END` | ビープ音終了時の音量 | 0.01 | |
 
+※1: AI_PROVIDER=geminiの場合は必須  
+※2: AI_PROVIDER=openaiの場合は必須
+
 ## 技術スタック
 
 ### バックエンド
 - **Flask 3.0.0** - Webアプリケーションフレームワーク
 - **google-generativeai 0.8.3** - Gemini API統合
+- **openai 1.101.0** - OpenAI API統合
 - **python-dotenv 1.0.0** - 環境変数管理
 
 ### フロントエンド

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ A classic terminal-style UI core. Provides an extensible project foundation from
 
 - Python 3.8 or higher (Check version: `python --version` or `python3 --version`)
 - pip (Python package manager, usually included with Python)
-- Google AI Studio API Key ([Get it here](https://aistudio.google.com/app/apikey))
+- API Key (depending on your chosen provider):
+  - Google AI Studio API Key ([Get it here](https://aistudio.google.com/app/apikey))
+  - Or OpenAI API Key ([Get it here](https://platform.openai.com/api-keys))
 
 ### Installation
 
@@ -78,12 +80,20 @@ cp .env.example .env
 
 #### 2. Set API Key
 
-Open `.env` file in a text editor and configure required settings:
+Open `.env` file in a text editor and configure based on your chosen AI provider:
 
+**For Gemini API (default):**
 ```bash
-# Only required items need to be changed (others use default values)
+AI_PROVIDER=gemini
 GEMINI_API_KEY=paste_your_api_key_here
-MODEL_NAME=gemini-2.0-flash  # or gemini-1.5-pro etc.
+GEMINI_MODEL_NAME=gemini-2.0-flash  # or gemini-1.5-pro etc.
+```
+
+**For OpenAI API:**
+```bash
+AI_PROVIDER=openai
+OPENAI_API_KEY=paste_your_api_key_here
+OPENAI_MODEL_NAME=gpt-4.1-mini  # or gpt-4.1 etc.
 ```
 
 Other settings (avatar name, UI speed, sound effects) have default values and work out of the box. You can customize them later as needed.
@@ -99,6 +109,11 @@ python app.py
 
 On successful launch, you'll see:
 ```
+=== Avatar UI Core ===
+AI Provider: gemini  # or openai
+Model: gemini-2.0-flash  # or gpt-4.1-mini etc.
+Server running at: http://localhost:5000
+====================
  * Running on http://127.0.0.1:5000
 ```
 
@@ -192,8 +207,13 @@ BEEP_DURATION_MS=30     # Duration (milliseconds)
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| `GEMINI_API_KEY` | Google Gemini API Key | - | ✅ |
-| `MODEL_NAME` | Gemini model to use | gemini-2.0-flash | ✅ |
+| `AI_PROVIDER` | AI provider to use (gemini/openai) | gemini | ✅ |
+| **Gemini API Settings** | | | |
+| `GEMINI_API_KEY` | Google Gemini API Key | - | ※1 |
+| `GEMINI_MODEL_NAME` | Gemini model to use | gemini-2.0-flash | |
+| **OpenAI API Settings** | | | |
+| `OPENAI_API_KEY` | OpenAI API Key | - | ※2 |
+| `OPENAI_MODEL_NAME` | OpenAI model to use | gpt-4.1-mini | |
 | **Server Settings** | | | |
 | `SERVER_PORT` | Server port number | 5000 | |
 | `DEBUG_MODE` | Enable debug mode | True | |
@@ -213,11 +233,15 @@ BEEP_DURATION_MS=30     # Duration (milliseconds)
 | `BEEP_VOLUME` | Beep volume (0.0-1.0) | 0.05 | |
 | `BEEP_VOLUME_END` | Beep end volume | 0.01 | |
 
+※1: Required when AI_PROVIDER=gemini  
+※2: Required when AI_PROVIDER=openai
+
 ## Tech Stack
 
 ### Backend
 - **Flask 3.0.0** - Web application framework
 - **google-generativeai 0.8.3** - Gemini API integration
+- **openai 1.101.0** - OpenAI API integration
 - **python-dotenv 1.0.0** - Environment variable management
 
 ### Frontend

--- a/app.py
+++ b/app.py
@@ -1,34 +1,31 @@
 """Webアプリケーション"""
+
 from flask import Flask, render_template, request, jsonify
 import settings
 import traceback
 
 # AI APIの初期化
 chat_session = None
+previous_response_id = None  # OpenAI Responses API用の前回のレスポンスID
 
 if settings.AI_PROVIDER == 'openai':
     # OpenAI API初期化
     from openai import OpenAI
-    
+
     client = OpenAI(api_key=settings.OPENAI_API_KEY)
-    
-    # チャット履歴を保持
-    messages = [
-        {"role": "system", "content": settings.SYSTEM_INSTRUCTION}
-    ]
-    
+
 elif settings.AI_PROVIDER == 'gemini':
     # Gemini API初期化
     import google.generativeai as genai
-    
+
     genai.configure(api_key=settings.GEMINI_API_KEY)
     model = genai.GenerativeModel(
-        model_name=settings.MODEL_NAME,
-        system_instruction=settings.SYSTEM_INSTRUCTION
+        model_name=settings.MODEL_NAME, system_instruction=settings.SYSTEM_INSTRUCTION
     )
     chat_session = model.start_chat()  # チャットセッション開始
 
 app = Flask(__name__)
+
 
 @app.route('/')
 def index():
@@ -45,76 +42,75 @@ def index():
         'avatar_image_idle': settings.AVATAR_IMAGE_IDLE,
         'avatar_image_talk': settings.AVATAR_IMAGE_TALK,
         'ai_provider': settings.AI_PROVIDER,
-        'model_name': settings.MODEL_NAME
+        'model_name': settings.MODEL_NAME,
     }
     return render_template('index.html', config=config)
+
 
 @app.route('/api/chat', methods=['POST'])
 def api_chat():
     """ユーザー入力を受信しAI応答を返す"""
     try:
         message = request.json['message']
-        
+
         if settings.AI_PROVIDER == 'openai':
-            # OpenAI Responses APIを使用
-            try:
-                # まず通常のChat Completions APIを試す
-                messages.append({"role": "user", "content": message})
-                
-                response = client.chat.completions.create(
+            global previous_response_id
+
+            # OpenAI Responses APIを使用（正式リリース版）
+            # 初回のリクエストか、継続のリクエストかで分岐
+            if previous_response_id is None:
+                # 初回：システムプロンプトとユーザーメッセージを含める
+                response = client.responses.create(
                     model=settings.MODEL_NAME,
-                    messages=messages,
-                    temperature=0.7,
-                    max_tokens=1000
+                    input=[
+                        {'role': 'system', 'content': settings.SYSTEM_INSTRUCTION},
+                        {'role': 'user', 'content': message},
+                    ],
                 )
-                
-                assistant_message = response.choices[0].message.content
-                messages.append({"role": "assistant", "content": assistant_message})
-                
-                return jsonify({'response': assistant_message})
-                
-            except AttributeError:
-                # Responses APIが利用可能な場合はこちらを使用
-                try:
-                    response = client.responses.create(
-                        model=settings.MODEL_NAME,
-                        instructions=settings.SYSTEM_INSTRUCTION,
-                        input=message
-                    )
-                    return jsonify({'response': response.output_text})
-                except:
-                    # フォールバック: 基本的なChat Completions API
-                    response = client.chat.completions.create(
-                        model=settings.MODEL_NAME,
-                        messages=[
-                            {"role": "system", "content": settings.SYSTEM_INSTRUCTION},
-                            {"role": "user", "content": message}
-                        ]
-                    )
-                    return jsonify({'response': response.choices[0].message.content})
-                    
+            else:
+                # 継続：previous_response_idを使って会話を継続
+                response = client.responses.create(
+                    model=settings.MODEL_NAME,
+                    input=message,
+                    previous_response_id=previous_response_id,
+                )
+
+            # レスポンスIDを保存
+            previous_response_id = response.id
+
+            # Responses APIの output_text プロパティから直接テキストを取得
+            ai_response = response.output_text
+
+            return jsonify({'response': ai_response})
+
         elif settings.AI_PROVIDER == 'gemini':
             # Gemini APIを使用
             response = chat_session.send_message(message)
             return jsonify({'response': response.text})
-            
+
     except Exception as e:
         # エラーハンドリング
-        error_message = f"Error occurred: {str(e)}"
-        print(f"[ERROR] {error_message}")
+        error_message = f'Error occurred: {str(e)}'
+        print(f'[ERROR] {error_message}')
         print(traceback.format_exc())
-        
-        return jsonify({
-            'error': error_message,
-            'provider': settings.AI_PROVIDER,
-            'model': settings.MODEL_NAME
-        }), 500
+
+        return (
+            jsonify(
+                {
+                    'error': error_message,
+                    'provider': settings.AI_PROVIDER,
+                    'model': settings.MODEL_NAME,
+                }
+            ),
+            500,
+        )
+
 
 if __name__ == '__main__':
-    print(f"=== Avatar UI Core ===")
-    print(f"AI Provider: {settings.AI_PROVIDER}")
-    print(f"Model: {settings.MODEL_NAME}")
-    print(f"Server running at: http://localhost:{settings.SERVER_PORT}")
-    print(f"====================")
-    
+    print(f'=== Avatar UI Core ===')
+    print(f'AI Provider: {settings.AI_PROVIDER}')
+    print(f'Model: {settings.MODEL_NAME}')
+    print(f'Server running at: http://localhost:{settings.SERVER_PORT}')
+    print(f'====================')
+
     app.run(debug=settings.DEBUG_MODE, port=settings.SERVER_PORT)

--- a/app.py
+++ b/app.py
@@ -1,15 +1,32 @@
 """Webアプリケーション"""
 from flask import Flask, render_template, request, jsonify
-import google.generativeai as genai
 import settings
+import traceback
 
-# Gemini API接続
-genai.configure(api_key=settings.GEMINI_API_KEY)
-model = genai.GenerativeModel(
-    model_name=settings.MODEL_NAME,
-    system_instruction=settings.SYSTEM_INSTRUCTION
-)
-chat = model.start_chat()  # チャットセッション開始
+# AI APIの初期化
+chat_session = None
+
+if settings.AI_PROVIDER == 'openai':
+    # OpenAI API初期化
+    from openai import OpenAI
+    
+    client = OpenAI(api_key=settings.OPENAI_API_KEY)
+    
+    # チャット履歴を保持
+    messages = [
+        {"role": "system", "content": settings.SYSTEM_INSTRUCTION}
+    ]
+    
+elif settings.AI_PROVIDER == 'gemini':
+    # Gemini API初期化
+    import google.generativeai as genai
+    
+    genai.configure(api_key=settings.GEMINI_API_KEY)
+    model = genai.GenerativeModel(
+        model_name=settings.MODEL_NAME,
+        system_instruction=settings.SYSTEM_INSTRUCTION
+    )
+    chat_session = model.start_chat()  # チャットセッション開始
 
 app = Flask(__name__)
 
@@ -26,16 +43,78 @@ def index():
         'beep_volume': settings.BEEP_VOLUME,
         'beep_volume_end': settings.BEEP_VOLUME_END,
         'avatar_image_idle': settings.AVATAR_IMAGE_IDLE,
-        'avatar_image_talk': settings.AVATAR_IMAGE_TALK
+        'avatar_image_talk': settings.AVATAR_IMAGE_TALK,
+        'ai_provider': settings.AI_PROVIDER,
+        'model_name': settings.MODEL_NAME
     }
     return render_template('index.html', config=config)
 
 @app.route('/api/chat', methods=['POST'])
 def api_chat():
     """ユーザー入力を受信しAI応答を返す"""
-    message = request.json['message']
-    response = chat.send_message(message)
-    return jsonify({'response': response.text})
+    try:
+        message = request.json['message']
+        
+        if settings.AI_PROVIDER == 'openai':
+            # OpenAI Responses APIを使用
+            try:
+                # まず通常のChat Completions APIを試す
+                messages.append({"role": "user", "content": message})
+                
+                response = client.chat.completions.create(
+                    model=settings.MODEL_NAME,
+                    messages=messages,
+                    temperature=0.7,
+                    max_tokens=1000
+                )
+                
+                assistant_message = response.choices[0].message.content
+                messages.append({"role": "assistant", "content": assistant_message})
+                
+                return jsonify({'response': assistant_message})
+                
+            except AttributeError:
+                # Responses APIが利用可能な場合はこちらを使用
+                try:
+                    response = client.responses.create(
+                        model=settings.MODEL_NAME,
+                        instructions=settings.SYSTEM_INSTRUCTION,
+                        input=message
+                    )
+                    return jsonify({'response': response.output_text})
+                except:
+                    # フォールバック: 基本的なChat Completions API
+                    response = client.chat.completions.create(
+                        model=settings.MODEL_NAME,
+                        messages=[
+                            {"role": "system", "content": settings.SYSTEM_INSTRUCTION},
+                            {"role": "user", "content": message}
+                        ]
+                    )
+                    return jsonify({'response': response.choices[0].message.content})
+                    
+        elif settings.AI_PROVIDER == 'gemini':
+            # Gemini APIを使用
+            response = chat_session.send_message(message)
+            return jsonify({'response': response.text})
+            
+    except Exception as e:
+        # エラーハンドリング
+        error_message = f"Error occurred: {str(e)}"
+        print(f"[ERROR] {error_message}")
+        print(traceback.format_exc())
+        
+        return jsonify({
+            'error': error_message,
+            'provider': settings.AI_PROVIDER,
+            'model': settings.MODEL_NAME
+        }), 500
 
 if __name__ == '__main__':
+    print(f"=== Avatar UI Core ===")
+    print(f"AI Provider: {settings.AI_PROVIDER}")
+    print(f"Model: {settings.MODEL_NAME}")
+    print(f"Server running at: http://localhost:{settings.SERVER_PORT}")
+    print(f"====================")
+    
     app.run(debug=settings.DEBUG_MODE, port=settings.SERVER_PORT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==3.0.0
 google-generativeai==0.8.3
+openai==1.101.0
 python-dotenv==1.0.0

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,7 @@
 """
 設定管理モジュール - .envファイルから全設定を読み込み
 """
+
 import os
 from dotenv import load_dotenv
 
@@ -11,9 +12,28 @@ load_dotenv()
 # 必須設定（環境変数が設定されていない場合はエラー）
 # ===========================================
 
-# AI設定
-GEMINI_API_KEY = os.environ['GEMINI_API_KEY']  # Gemini APIキー
-MODEL_NAME = os.environ['MODEL_NAME']  # 使用するGeminiモデル
+# AIプロバイダー選択
+AI_PROVIDER = os.getenv('AI_PROVIDER', 'gemini').lower()  # gemini または openai
+
+# プロバイダー別のAPI設定
+if AI_PROVIDER == 'openai':
+    # OpenAI API設定
+    OPENAI_API_KEY = os.environ.get('OPENAI_API_KEY')
+    if not OPENAI_API_KEY:
+        raise ValueError('AI_PROVIDER=openai is set but OPENAI_API_KEY is not found')
+    MODEL_NAME = os.getenv('OPENAI_MODEL_NAME', 'gpt-4.1-mini')
+
+elif AI_PROVIDER == 'gemini':
+    # Gemini API設定
+    GEMINI_API_KEY = os.environ.get('GEMINI_API_KEY')
+    if not GEMINI_API_KEY:
+        raise ValueError('AI_PROVIDER=gemini is set but GEMINI_API_KEY is not found')
+    MODEL_NAME = os.getenv('GEMINI_MODEL_NAME', 'gemini-2.0-flash')
+
+else:
+    raise ValueError(
+        f'Unsupported AI provider: {AI_PROVIDER}. Please specify gemini or openai.'
+    )
 
 # ===========================================
 # 任意設定（デフォルト値あり）


### PR DESCRIPTION
## Summary

**OpenAI API**のサポートを追加しました。

## Changes

### ✨ New Features
- **マルチAIプロバイダー対応**: 環境変数`AI_PROVIDER`で`gemini`または`openai`を選択可能
- **OpenAI Responses API対応**: セッション管理機能を持つResponses APIで実装し、チャット履歴の管理を改善
- **柔軟な設定管理**: プロバイダーごとに異なるAPIキーとモデル名を設定可能

### 📝 Modified Files

#### Backend
- **app.py**
  - OpenAI APIクライアントの初期化処理を追加
  - OpenAI Responses APIを使用した実装に更新
  - チャット履歴管理の改善（メッセージ履歴の構造化）
  - API呼び出しロジックをプロバイダー別に分岐

- **settings.py**
  - `AI_PROVIDER`による動的なAPI設定の切り替え
  - OpenAI用の環境変数（`OPENAI_API_KEY`, `OPENAI_MODEL_NAME`）を追加
  - エラーメッセージを英語化

#### Configuration
- **requirements.txt**
  - `openai==1.101.0`を追加

- **.env.example**
  - OpenAI API設定のテンプレートを追加
  - プロバイダー選択の説明を追加

#### Documentation
- **README.md / README.ja.md**
  - OpenAI APIのセットアップ手順を追加
  - 環境変数一覧を更新
  - 技術スタックにOpenAI SDKを追加

## Usage

### Gemini API（デフォルト）
```bash
AI_PROVIDER=gemini
GEMINI_API_KEY=your_gemini_api_key
GEMINI_MODEL_NAME=gemini-2.0-flash
```

### OpenAI API
```bash
AI_PROVIDER=openai
OPENAI_API_KEY=your_openai_api_key
OPENAI_MODEL_NAME=gpt-4o-mini
```

## Testing
- ✅ Gemini APIでの動作確認
- ✅ OpenAI APIでの動作確認
- ✅ エラーハンドリングの確認

## Breaking Changes
- 環境変数 `MODEL_NAME` を `GEMINI_MODEL_NAME` および `OPENAI_MODEL_NAME` に分割
  - 各プロバイダーごとに異なるモデル名を設定可能になりました。既存の `.env` ファイルは更新が必要です。
  - ただ、モデル名は複数プロバイダーで共通の `MODEL_NAME` 変数を使うのでも良いかもしれません。
